### PR TITLE
Minor Bug Fixes - idempotencyKey and user metadata array

### DIFF
--- a/src/Resources/AbstractResource.php
+++ b/src/Resources/AbstractResource.php
@@ -24,7 +24,7 @@ abstract class AbstractResource
 	 *
 	 * @var string
 	 */
-	protected $idempotency_key;
+	protected $idempotencyKey;
 
 	/**
 	 * Plaid client Id.
@@ -59,7 +59,7 @@ abstract class AbstractResource
 	) {
 		$this->httpClient = $httpClient;
 		$this->api_key = $api_key;
-		$this->idempotency_key = $this->getIdempotencyKey();
+		$this->idempotencyKey = $this->getIdempotencyKey();
 		$this->hostname = $hostname;
 	}
 
@@ -72,7 +72,7 @@ abstract class AbstractResource
 	protected function paramsWithClientCredentials(array $params = []): array
 	{
 		return \array_merge([
-			"idempotency_key" => $this->idempotency_key,
+			"idempotencyKey" => $this->idempotencyKey,
 		], $params);
 	}
 

--- a/src/Resources/Payments.php
+++ b/src/Resources/Payments.php
@@ -97,7 +97,7 @@ class Payments extends AbstractResource
 			"billingDetails" => $billing->toArray(),
 			"expMonth" => $expMonth,
 			"expYear" => $expYear,
-			"metadata" => $userMetadata
+			"metadata" => $userMetadata->toArray()
 		];
 
 		return $this->sendRequest(
@@ -123,7 +123,7 @@ class Payments extends AbstractResource
 		$params = [
 			"plaidProcessorToken" => $plaidToken,
 			"billingDetails" => $billing->toArray(),
-			"metadata" => $userMetadata
+			"metadata" => $userMetadata->toArray()
 		];
 
 		return $this->sendRequest(

--- a/src/Resources/Payouts.php
+++ b/src/Resources/Payouts.php
@@ -4,7 +4,7 @@ namespace Keinher\Circle\Resources;
 
 class Payouts extends AbstractResource
 {
-    protected $idempotency_key;
+    protected $idempotencyKey;
 
     /**
      * Create a payout


### PR DESCRIPTION
- idempotencyKey is the attribute name required by the Circle API for payments and payouts, this fixes a 400 error received when sending the wrong attribute name.
- Sending the user metadata as an array instead of an object, this is more consistent with the billing information being sent as an array.

